### PR TITLE
Invalid cast exception fix

### DIFF
--- a/Assets/GILES/Code/Classes/GUI/pb_InspectorResolver.cs
+++ b/Assets/GILES/Code/Classes/GUI/pb_InspectorResolver.cs
@@ -58,8 +58,8 @@ namespace GILES.Interface
 
 			List<GameObject> inspectors = new List<GameObject>();
 
-			foreach(KeyValuePair<IEnumerable<Attribute>, GameObject> kvp in inspectorLookup)
-			{
+            foreach(KeyValuePair<IEnumerable<Attribute>, GameObject> kvp in inspectorLookup)
+            {
                 foreach(Attribute attrib in kvp.Key)
                 {
                     if (attrib is pb_TypeInspectorAttribute)
@@ -80,7 +80,7 @@ namespace GILES.Interface
                         }
                     }
                 }
-			}
+            }
 
 EXACT_TYPE_INSPECTOR_FOUND:
 


### PR DESCRIPTION
**Quick question:**

Could I have your tab settings? The code looks well indented in Visual Studio, but clearly other applications disagree :\

Anyway...

Error occurs within the Unity editor. Haven't tested with actual build.

**Reproducing error:**
1. Checkout "a4dd96a" commit.
2. Open Unity.
3. Open "Level Editor" scene.
4. Press play.
5. Add a new object to the scene from resource browser.
6. Select the new game object by pressing on it with the mouse within the game view.

I don't know if this is the absolute best way of fixing this error, but it does seem to fix the issue and doesn't seem to have any side effects. I may be missing something because I don't know the codebase intimately though.

**Unity version:** 5.3.1p3

**Error Log:**

InvalidCastException: Cannot cast from source type to destination type.
GILES.Interface.pb_InspectorResolver.GetInspector (System.Type type) (at Assets/GILES/Code/Classes/GUI/pb_InspectorResolver.cs:63)
GILES.Interface.pb_TransformEditor.InitializeGUI () (at Assets/GILES/Code/Classes/GUI/Component Editors/pb_TransformEditor.cs:21)
GILES.Interface.pb_ComponentEditor.SetComponent (UnityEngine.Component target) (at Assets/GILES/Code/Classes/GUI/Component Editors/pb_ComponentEditor.cs:44)
GILES.Interface.pb_ComponentEditorResolver.GetEditor (UnityEngine.Component component) (at Assets/GILES/Code/Classes/GUI/pb_ComponentEditorResolver.cs:48)
GILES.Interface.pb_Inspector.RebuildInspector (UnityEngine.GameObject go) (at Assets/GILES/Code/Scripts/GUI/pb_Inspector.cs:78)
GILES.Interface.pb_Inspector.OnSelectionChange (IEnumerable`1 selection) (at Assets/GILES/Code/Scripts/GUI/pb_Inspector.cs:50)
GILES.pb_Selection.SetSelection (IEnumerable`1 selection) (at Assets/GILES/Code/Classes/pb_Selection.cs:102)
GILES.pb_Selection.SetSelection (UnityEngine.GameObject selection) (at Assets/GILES/Code/Classes/pb_Selection.cs:110)
GILES.Interface.pb_PrefabBrowserItemButton.Instantiate () (at Assets/GILES/Code/Scripts/GUI/pb_PrefabBrowserItemButton.cs:179)
UnityEngine.Events.InvokableCall.Invoke (System.Object[] args) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent.cs:144)
UnityEngine.Events.InvokableCallList.Invoke (System.Object[] parameters) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent.cs:621)
UnityEngine.Events.UnityEventBase.Invoke (System.Object[] parameters) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent.cs:756)
UnityEngine.Events.UnityEvent.Invoke () (at C:/buildslave/unity/build/Runtime/Export/UnityEvent_0.cs:53)
UnityEngine.UI.Button.Press () (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/Button.cs:35)
UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/Button.cs:44)
UnityEngine.EventSystems.ExecuteEvents.Execute (IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:52)
UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler](UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor) (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:269)
UnityEngine.EventSystems.EventSystem:Up
