### PR TITLE
pb_reflection_null_arg: no longer wrongly passing a null argument.

### DIFF
--- a/Assets/GILES/Code/Classes/pb_Reflection.cs
+++ b/Assets/GILES/Code/Classes/pb_Reflection.cs
@@ -55,7 +55,7 @@ namespace GILES
 
 		public static Dictionary<string, object> ReflectProperties<T>(T obj, HashSet<string> ignoreFields)
 		{
-			return ReflectProperties<T>(obj, BindingFlags.Instance | BindingFlags.Public, null);
+			return ReflectProperties<T>(obj, BindingFlags.Instance | BindingFlags.Public, ignoreFields);
 		}
 
 		public static Dictionary<string, object> ReflectProperties<T>(T obj, BindingFlags flags, HashSet<string> ignoreFields)


### PR DESCRIPTION
It seems like one of the convenience property reflection methods is incorrectly passing a null argument?
